### PR TITLE
seperate latest tfl code from db operations

### DIFF
--- a/lib/LineStatus.js
+++ b/lib/LineStatus.js
@@ -9,21 +9,38 @@ var dbTableName = 'line-status'
 var serviceDescriptions = require('./serviceDescriptions.js')
 
 /*
-grabs the current status code from TFL and updates the line object in the db.
-With updated scoreArray from the db, builds an object containing current and lastHour strings.
-This is ready to be consumed by the client.
+Performs two async tasks:
+Grabs the latest status code from TFL.
+Also, gets the scoreArray from the line object in the DB.
+When both tasks are complete, it then builds the response object and returns it.
+See buildResponseObject for details on what looks like.
 */
 function getStatus(lineId) {
-  return Tfl.updateStatus(lineId).then(res =>{
-    return buildResponseObject(JSON.parse(res))
+  var tasks = [
+    Tfl.getStatusFromTfl(lineId),
+    Line.getScoreArray(lineId, dbTableName)
+  ]
+  return Promise.all(tasks).then(responses => {
+    return buildResponseObject(responses)
   })
 }
 
-function buildResponseObject(array) {
+/*
+Turns the raw response from TFL and the raw string of statuses from the DB
+into a response object ready to be consumed by the client.
+`rawArray` should contain two items:
+An integer at pos 0
+A parsable array of integers at pos 1
+
+This function does some parsing of its own and returns an object
+*/
+function buildResponseObject(rawArray) {
+  var currentCode = rawArray[0]
+  var historyArray = JSON.parse(rawArray[1])
   return {
-    current: serviceDescriptions.byCode(array[0]),
-    lastHour: scoreLastHour(array),
-    raw: array
+    current: serviceDescriptions.byCode(currentCode),
+    lastHour: scoreLastHour(historyArray),
+    raw: [currentCode, historyArray]
   }
 }
 

--- a/lib/Tfl.js
+++ b/lib/Tfl.js
@@ -70,5 +70,6 @@ function getCode(response){
 
 module.exports = {
   poll: poll,
-  updateStatus: updateStatus
+  updateStatus: updateStatus,
+  getStatusFromTfl: getStatusFromTfl
 }

--- a/server.js
+++ b/server.js
@@ -40,8 +40,8 @@ app.get('/', (req, res) => {
 API:
 The /lines/:id endpoint returns an object containing three fields:
 object.current is the latest status, which is fetched from the TFL API when the request is made
-object.lastHouse is an aggregated description of the last hour's service statuses.
-object.raw is the raw array returned by the DB
+object.lastHour is an aggregated description of the last hour's service statuses.
+object.raw is an array of the latest code and the 12 previous codes from the DB.
 */
 app.get('/lines/:id', (req, res) => {
   LineStatus.getStatus(req.params.id).then(data => {


### PR DESCRIPTION
A quick update to separate the act of hitting the endpoint with the act of updating the DB.

Solves the issue outlined in #10 