### PR TITLE
Add cron tasks

### DIFF
--- a/db/seed.js
+++ b/db/seed.js
@@ -9,13 +9,14 @@ dotenv.load()
 // NOTE: ensure you have aws-cli on your machine!
 var AWS = require('aws-sdk')
 AWS.config.region = process.env.AWS_REGION
-var Dynamo = new AWS.DynamoDB();
 
 /*
 LOCAL ONLY! Uncomment the line below to set the endpoint to your local machine.
 Make sure you have your own env var set here, or you'll be connecting to aws.
 */
-// AWS.config.endpoint = process.env.AWS_ENDPOINT
+AWS.config.update({endpoint: process.env.AWS_ENDPOINT});
+
+var Dynamo = new AWS.DynamoDB();
 
 // import crud functions
 var crud = require('../models/database.js')
@@ -121,7 +122,7 @@ function run(seedData) {
       }).catch(err => {
         console.log(err)
       })
-    }, 5000)
+    }, 10000)
   })
 }
 

--- a/lib/Tfl.js
+++ b/lib/Tfl.js
@@ -1,27 +1,33 @@
 // INTERACTS WITH THE TFL API
 
+// 3rd Party Modules
 var request = require('request')
 const debug = require('debug')('Tfl')
+var cron = require('node-cron')
+
+// Environment Variables
 var appKey = process.env.TFL_APP_KEY
 var appId = process.env.TFL_APP_ID
 var tflServer = process.env.TFL_SERVER
 var lineStatusTable = process.env.LINE_STATUS_TABLE
 var feedbackTable = process.env.FEEDBACK_TABLE
+
+// Local Modules
 var Line = require('../models/line.js')
 
 /*
-POLLS THE TFL API EVERY FIVE MINUTES.
-FETCHES THE CURRENT STATUS OF EACH LINE AND UPDATES THE RECORD IN THE DB
-(SEE UPDATESTATUS FOR DETAILS)
-BY DEFAULT, THIS IS EXPORTED TO THE SERVER.JS FILE SO IT CAN BE STARTED WHEN
-THE SERVER STARTS.
+A cron task that runs every five minutes during the regular tube hours.
+Currently: it runs from 5am to midnight.
+It takes in an array of Line ids and, for each of them, requests the status
+of that line from TFL and updates the object in the DB.
+This is exported to server.js so it can be started when the server is.
 */
-function poll(idArray) {
-  idArray.forEach(lineId => {
-    setInterval(function(){
+function schedule(idArray) {
+  cron.schedule('*/5 0,5-23 * * *', () =>{
+    idArray.forEach(lineId => {
       debug('Polling TFL for ' + lineId + ' at: ' + new Date())
       return updateStatus(lineId)
-    }, 300000)
+    })
   })
 }
 
@@ -71,7 +77,7 @@ function getCode(response){
 }
 
 module.exports = {
-  poll: poll,
+  schedule: schedule,
   updateStatus: updateStatus,
   getStatusFromTfl: getStatusFromTfl
 }

--- a/models/database.js
+++ b/models/database.js
@@ -9,7 +9,8 @@ working on a local version of dynamodb.
 Otherwise, please ensure you are connecting to AWS's `commuter-dev` environment
 and not production.
 */
-//AWS.config.endpoint = process.env.AWS_ENDPOINT
+AWS.config.update({endpoint: process.env.AWS_ENDPOINT});
+
 const Dynamo = new AWS.DynamoDB.DocumentClient();
 
 function writeToDB(item, table){

--- a/models/database.js
+++ b/models/database.js
@@ -9,7 +9,7 @@ working on a local version of dynamodb.
 Otherwise, please ensure you are connecting to AWS's `commuter-dev` environment
 and not production.
 */
-AWS.config.update({endpoint: process.env.AWS_ENDPOINT});
+// AWS.config.update({endpoint: process.env.AWS_ENDPOINT});
 
 const Dynamo = new AWS.DynamoDB.DocumentClient();
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -622,6 +622,11 @@
       "from": "negotiator@0.6.1",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz"
     },
+    "node-cron": {
+      "version": "1.1.2",
+      "from": "node-cron@latest",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-1.1.2.tgz"
+    },
     "oauth-sign": {
       "version": "0.8.2",
       "from": "oauth-sign@>=0.8.1 <0.9.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "aws-sdk": "^2.7.5",
     "body-parser": "^1.15.2",
     "chai": "*",
     "debug": "^2.3.2",
@@ -20,10 +21,8 @@
     "express": "^4.14.0",
     "mocha": "*",
     "morgan": "^1.7.0",
-    "request": "^2.78.0",
-    "aws-sdk": "^2.7.5",
-    "debug": "^2.3.2"
+    "node-cron": "^1.1.2",
+    "request": "^2.78.0"
   },
-  "devDependencies": {
-  }
+  "devDependencies": {}
 }

--- a/server.js
+++ b/server.js
@@ -1,3 +1,4 @@
+// 3rd Party Modules
 var dotenv = require('dotenv');
 dotenv.load();
 var express = require('express');
@@ -6,50 +7,40 @@ var jsonParser = bodyParser.json();
 var morgan = require('morgan');
 const debug = require('debug')('server');
 var app = express();
+
+// Environment Variables
 var port = process.env.PORT || 3001
 
-// TO LOG THE REQUESTS IN DEV MODE
-// uncomment the following line
-app.use(morgan('dev'))
-
-// TO START THE FAKETFLSERVER (For dev purposes)
-// uncomment these next two lines!
-// var fakeTflServer = require('./fakeTflServer.js');
-// fakeTflServer();
-
+// Local Dependencies
 var Tfl = require('./lib/Tfl.js')
 var LineStatus = require('./lib/LineStatus.js');
 var SupportedLines = require('./lib/SupportedLines.js')();
 var database = require('./models/database.js');
 var Feedback = require('./models/feedback.js');
-
-// POLL TFL FOR THE STATUS OF EACH OF THE LINES
 var lineIds = SupportedLines.map(el => { return el.id })
 
+/*
+Local Development Set up
+*/
+// LOG THE REQUESTS IN DEV MODE
+app.use(morgan('dev'))
+// START THE FAKETFLSERVER
+// var fakeTflServer = require('./fakeTflServer.js');
+// fakeTflServer();
 
+/*
+Scheduled tasks
+*/
+// POLL TFL FOR THE STATUS OF EACH OF THE LINES EVERY 5 MINS
+Tfl.schedule(lineIds)
 
+// TODO: CREATE A TASK THAT RUNS EACH HOUR AND UPDATES WITH HISTORIC DATA
 
-
-
-// Tfl.poll(lineIds)
-
-
-
-
-
-
-
-
-// RENDER A BASIC HOMEPAGE AT ROOT
-//TODO: remove this as no one should be hitting this endpoint.
-app.get('/', (req, res) => {
-  var title = `<h1> Tube Status </h1><br>`
-  function links(lines){
-    return lines.map((el) =>{
-      return `<br><a href="/lines/${el.id}">${el.name} Line</a>`
-    })
-  }
-  res.send(title + links(SupportedLines))
+/*
+Server starts here
+*/
+app.get('/', (req,res) => {
+  res.send("SERVICE OK")
 })
 
 /*


### PR DESCRIPTION
this PR replaces the `poll` function that was doing the updating of line statuses with a cron task.

This cron task allows flexibility: the task is now only ran from 5am to midnight, during regular hours of operation of the tube. It will need to be amended if/when the app supports the night tube.