### PR TITLE
add middleware to allow cors

### DIFF
--- a/server.js
+++ b/server.js
@@ -36,6 +36,17 @@ Tfl.schedule(lineIds)
 
 // TODO: CREATE A TASK THAT RUNS EACH HOUR AND UPDATES WITH HISTORIC DATA
 
+
+/*
+Middleware:
+*/
+// Allow CORS so that the web app can make requests.
+app.use((req, res, next) => {
+  res.header("Access-Control-Allow-Origin", "*");
+  res.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
+  next();
+});
+
 /*
 Server starts here
 */


### PR DESCRIPTION
this PR adds a piece of middleware that every request is put through:

it allows CORS. SO question [here](http://stackoverflow.com/questions/36878255/allow-access-control-allow-origin-header-using-html5-fetch-api) in case future me gets confused.

Code is courtesy of Sean.